### PR TITLE
Ignore npm-debug.log when committing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ dist
 .tmp
 .sass-cache
 bower_components
+npm-debug.log


### PR DESCRIPTION
This file is completely setup-dependent and should clearly not be
version-checked.
